### PR TITLE
Use correct method when calling API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@
 
 Code sample for helping TPPs and ASPSP using the ForgeRock Open Banking reference implementation platform.
 
-## Licence
-License:	CDDLv1.0 \
-License URL	: http://forgerock.org/cddlv1-0/
-
 
 ## How to install the app
 
@@ -46,3 +42,7 @@ To follow and complete the exercise go to https://qcastel.github.io/
 
 https://qcastel.github.io/ is the hosted docs from [docs](forgerock-openbanking-excercise-tpp/src/docs)
 
+
+## Licence
+License:	CDDLv1.0 \
+License URL	: http://forgerock.org/cddlv1-0/

--- a/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/api/account/AccountsAPIController.java
+++ b/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/api/account/AccountsAPIController.java
@@ -15,7 +15,7 @@ public class AccountsAPIController implements AccountsAPI {
     private RSAccountAPIService rsAccountAPIService;
 
     @Override
-    public ResponseEntity<String> readAccounts(
+    public ResponseEntity readAccounts(
             @RequestParam(value = "aspspId") String aspspId,
             @RequestHeader(value = "accessToken") String accessToken) {
         //TODO: exercise: retrieve the aspsp configuration

--- a/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/api/account/AccountsAPIController.java
+++ b/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/api/account/AccountsAPIController.java
@@ -1,6 +1,9 @@
 package com.forgerock.openbanking.exercise.tpp.api.account;
 
+import com.forgerock.openbanking.exercise.tpp.repository.AspspConfigurationRepository;
 import com.forgerock.openbanking.exercise.tpp.services.aspsp.rs.RSAccountAPIService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -11,8 +14,12 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 @Controller
 public class AccountsAPIController implements AccountsAPI {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccountsAPIController.class);
+
     @Autowired
     private RSAccountAPIService rsAccountAPIService;
+    @Autowired
+    private AspspConfigurationRepository aspspConfigurationRepository;
 
     @Override
     public ResponseEntity readAccounts(

--- a/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/api/registration/TPPRegistration.java
+++ b/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/api/registration/TPPRegistration.java
@@ -65,11 +65,11 @@ public interface TPPRegistration {
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
             @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
 
-    @RequestMapping(value = "/aspsp/{aspspId}",
+    @RequestMapping(value = "/aspsp",
             method = RequestMethod.DELETE)
     ResponseEntity<AspspConfiguration> unregisterToAspsp(
-            @ApiParam(value = "The ASPSP ID", required = true)
-            @PathVariable("aspspId") String aspspId
+            @ApiParam(value = "The ASPSP-AS OIDC root endpoint", required = true)
+            @RequestHeader("as_discovery_endpoint") String oidcRootEndpoint
     );
 
     @RequestMapping(value = "/aspsp",

--- a/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/exceptions/ApiExceptionHandler.java
+++ b/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/exceptions/ApiExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.forgerock.openbanking.exercise.tpp.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(value = Throwable.class)
+    protected ResponseEntity<Object> handle() {
+        return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}
+

--- a/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/model/aspsp/AspspConfiguration.java
+++ b/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/model/aspsp/AspspConfiguration.java
@@ -42,6 +42,10 @@ public class AspspConfiguration {
         return id;
     }
 
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public String getName() {
         return name;
     }

--- a/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/services/aspsp/rs/RSAccountAPIService.java
+++ b/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/services/aspsp/rs/RSAccountAPIService.java
@@ -118,7 +118,7 @@ public class RSAccountAPIService {
      */
     public OBReadAccount2 readAccounts(AspspConfiguration aspspConfiguration, String accessToken)
             throws Exception {
-        //TODO exercise: Use the postman and the createAccountRequest() to implement a similar function, that does retrieve the user accounts from the RS-ASPSP
+        // TODO exercise: Use postman and the method createAccountRequest() to implement a similar function, that retrieves the user accounts from the RS-ASPSP
         return null;
     }
 }

--- a/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/services/aspsp/rs/RSAccountAPIService.java
+++ b/forgerock-openbanking-excercise-tpp/src/main/java/com/forgerock/openbanking/exercise/tpp/services/aspsp/rs/RSAccountAPIService.java
@@ -32,10 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.org.openbanking.OBHeaders;
-import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
-import uk.org.openbanking.datamodel.account.OBReadData1;
-import uk.org.openbanking.datamodel.account.OBReadRequest1;
-import uk.org.openbanking.datamodel.account.OBReadResponse1;
+import uk.org.openbanking.datamodel.account.*;
 
 import javax.annotation.Resource;
 import java.util.UUID;
@@ -119,7 +116,7 @@ public class RSAccountAPIService {
      * @return the PSU accounts
      * @throws Exception
      */
-    public OBReadResponse1 readAccounts(AspspConfiguration aspspConfiguration, String accessToken)
+    public OBReadAccount2 readAccounts(AspspConfiguration aspspConfiguration, String accessToken)
             throws Exception {
         //TODO exercise: Use the postman and the createAccountRequest() to implement a similar function, that does retrieve the user accounts from the RS-ASPSP
         return null;

--- a/forgerock-openbanking-excercise-tpp/src/test/java/com/forgerock/openbanking/exercise/tpp/account/AccountsApiTest.java
+++ b/forgerock-openbanking-excercise-tpp/src/test/java/com/forgerock/openbanking/exercise/tpp/account/AccountsApiTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.org.openbanking.datamodel.account.OBReadAccount2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,7 +21,7 @@ public class AccountsApiTest extends PostAISPAccessTokenTest {
     @Test
     public void getAccounts() throws Exception {
         String obPaymentSubmissionResponseSerialised = this.mockMvcForDocs.perform(
-                post("/api/open-banking/accounts/")
+                get("/api/open-banking/accounts/")
                         .param("aspspId", aspspConfigId)
                         .param("accessToken", accessToken)
         )

--- a/forgerock-openbanking-excercise-tpp/src/test/java/com/forgerock/openbanking/exercise/tpp/account/AccountsApiTest.java
+++ b/forgerock-openbanking-excercise-tpp/src/test/java/com/forgerock/openbanking/exercise/tpp/account/AccountsApiTest.java
@@ -23,7 +23,7 @@ public class AccountsApiTest extends PostAISPAccessTokenTest {
         String obPaymentSubmissionResponseSerialised = this.mockMvcForDocs.perform(
                 get("/api/open-banking/accounts/")
                         .param("aspspId", aspspConfigId)
-                        .param("accessToken", accessToken)
+                        .header("accessToken", accessToken)
         )
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();

--- a/forgerock-openbanking-excercise-tpp/src/test/java/com/forgerock/openbanking/exercise/tpp/account/AccountsApiTest.java
+++ b/forgerock-openbanking-excercise-tpp/src/test/java/com/forgerock/openbanking/exercise/tpp/account/AccountsApiTest.java
@@ -17,7 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 public class AccountsApiTest extends PostAISPAccessTokenTest {
 
-    @Ignore("not ready yet")
     @Test
     public void getAccounts() throws Exception {
         String obPaymentSubmissionResponseSerialised = this.mockMvcForDocs.perform(


### PR DESCRIPTION
The accounts method to be implemented is a GET request. The test
should be calling that unimplemented GET API.